### PR TITLE
STUD-13998: undo STUD-14016 changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake'
-gem 'actionpack', '~> 5.0'
-gem 'activemodel', '~> 5.0'
+gem 'actionpack', '~> 5.1'
+gem 'activemodel', '~> 5.1'
 
 
 group :test do

--- a/lib/mongoid/interceptable.rb
+++ b/lib/mongoid/interceptable.rb
@@ -254,8 +254,12 @@ module Mongoid
           chain.append(callback) if callback.kind == place
         end
         self.class.send :define_method, name do
-          runner = ActiveSupport::Callbacks::Filters::Environment.new(self, false, nil)
-          chain.compile.call(runner).value
+          env = ActiveSupport::Callbacks::Filters::Environment.new(self, false, nil)
+          sequence = chain.compile
+          sequence.invoke_before(env)
+          env.value = !env.halted
+          sequence.invoke_after(env)
+          env.value
         end
         self.class.send :protected, name
       end

--- a/lib/mongoid/version.rb
+++ b/lib/mongoid/version.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
 module Mongoid
-  # DANGER: Fake using Mongoid 6.1 to bypass having to upgrade dependencies.
-  VERSION = "6.3.1"
+  VERSION = "6.3.0"
 end

--- a/mongoid.gemspec
+++ b/mongoid.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "mongoid"
 
-  s.add_dependency("activemodel", ["~> 5.0"])
+  s.add_dependency("activemodel", ["~> 5.1"])
   s.add_dependency("mongo", ['>=2.5.0', '<3.0.0'])
 
   s.files        = Dir.glob("lib/**/*") + %w(CHANGELOG.md LICENSE README.md Rakefile)


### PR DESCRIPTION
Undoing changes made in: https://github.com/kapost/mongoid/commit/bb7b867780fad8a4a92dce16af3ab36083c7a34b as we have upgraded to rails 5.1 in Napa and use the globally available mongoid gem.